### PR TITLE
Manually convert character to integer (1.9.x won't auto-convert)

### DIFF
--- a/lib/abnf.rb
+++ b/lib/abnf.rb
@@ -37,7 +37,7 @@ module ABNF
     end
     
     def first
-      @s[0]
+      @s[0].ord if @s[0]
     end
     
     def rest


### PR DESCRIPTION
Ruby 1.9.x never auto-converts chars to integers, the Stream class needs to do this to interoperate properly with the Range matchers.
